### PR TITLE
Force installation of docker 18.06

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,7 @@ sudo update-rc.d dphys-swapfile remove
 #
 # Install Docker / Docker Compose
 #
+export VERSION=18.06
 curl -sSL get.docker.com | sh && sudo usermod pi -aG docker
 sudo apt-get install -qqy docker-compose
 #


### PR DESCRIPTION
Currently, only docker 18.06 is validated to work with Kubernetes, so to avoid future surprises, we are forcing the installation of v18.06